### PR TITLE
Using Java 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
None Java 1.8 feature it's used until now, this downgrade to Java 1.7 allows the library to be used in more projects.