### PR TITLE
Added an option to set server properties for the broker

### DIFF
--- a/src/main/java/com/github/charithe/kafka/KafkaJunitRule.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitRule.java
@@ -56,6 +56,7 @@ public class KafkaJunitRule extends ExternalResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaJunitRule.class);
     private static final int ALLOCATE_RANDOM_PORT = -1;
     private static final String LOCALHOST = "localhost";
+    private Properties brokerProperties=null;
 
     private TestingServer zookeeper;
     private KafkaServerStartable kafkaServer;
@@ -72,6 +73,18 @@ public class KafkaJunitRule extends ExternalResource {
     public KafkaJunitRule(final int kafkaPort, final int zookeeperPort){
         this(kafkaPort);
         this.zookeeperPort = zookeeperPort;
+    }
+
+    /**
+     *
+     * @param brokerProperties any additional properties that should be passed to the broker such as
+     *                         default number of partitions, io threads, etc.  These properties will
+     *                         be merged with, but not override, the properties required for the broker
+     *                         to work.
+     */
+    public KafkaJunitRule(final int kafkaPort, final int zookeeperPort,Properties brokerProperties){
+        this(kafkaPort,zookeeperPort);
+        this.brokerProperties=brokerProperties;
     }
 
 
@@ -158,11 +171,15 @@ public class KafkaJunitRule extends ExternalResource {
         kafkaLogDir = Files.createTempDirectory("kafka_junit");
 
         Properties props = new Properties();
+        if(brokerProperties!=null){
+            props.putAll(brokerProperties);
+        }
         props.put("advertised.host.name", LOCALHOST);
         props.put("port", kafkaPort + "");
         props.put("broker.id", "1");
         props.put("log.dirs", kafkaLogDir.toAbsolutePath().toString());
         props.put("zookeeper.connect", zookeeperQuorum);
+
 
         return new KafkaConfig(props);
     }

--- a/src/test/java/com/github/charithe/kafka/KafkaJunitPropertiesTest.java
+++ b/src/test/java/com/github/charithe/kafka/KafkaJunitPropertiesTest.java
@@ -1,0 +1,55 @@
+package com.github.charithe.kafka;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by eh on 1/8/16.
+ */
+public class KafkaJunitPropertiesTest {
+
+    public static Properties kafkaProps=new Properties();
+    static{
+        kafkaProps.setProperty("num.partitions","5");
+    }
+    @Rule
+    public KafkaJunitRule kafkaRule = new KafkaJunitRule(9095,2014,kafkaProps);
+
+    @Test(timeout = 10000)
+    public void ensureMultiplePartitionsTest() throws ExecutionException, InterruptedException {
+        Properties props = new Properties();
+        props.put("bootstrap.servers", "localhost:9095");
+        props.put("acks", "all");
+        props.put("retries", 0);
+        props.put("batch.size", 16384);
+        props.put("linger.ms", 1);
+        props.put("buffer.memory", 33554432);
+        props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+        KafkaProducer<String,String> producer=new KafkaProducer<String, String>(props);
+        ProducerRecord<String,String> record;
+
+        record=new ProducerRecord<String, String>("newTopic",0,"key","value");
+        Future<RecordMetadata> f =producer.send(record);
+        assertEquals(f.get().partition(),0);
+
+        record=new ProducerRecord<String, String>("newTopic",3,"key","value");
+        f =producer.send(record);
+        assertEquals(f.get().partition(),3);
+
+        record=new ProducerRecord<String, String>("newTopic",4,"key","value");
+        f =producer.send(record);
+        assertEquals(f.get().partition(),4);
+    }
+}


### PR DESCRIPTION
So, we have been using this plugin to do quite a few of our tests, but we really wanted the ability to specify some of the broker config properties when we initiate the rule.  I also included a test to verify that a property is passed through, and takes effect.  

Tests target the 0.9.0 API.