### PR TITLE
Message consumption

### DIFF
--- a/src/main/java/com/github/charithe/kafka/KafkaJunitRule.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitRule.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.*;
@@ -276,7 +277,10 @@ public class KafkaJunitRule extends ExternalResource {
                 List<T> messages = new ArrayList<>(expectedMessages);
                 while (messages.size() < expectedMessages && !Thread.currentThread().isInterrupted()) {
                     ConsumerRecords<T, T> records = consumer.poll(POLL_TIMEOUT_MS);
-                    for (ConsumerRecord<T, T> rec : records) {
+                    for (Iterator<ConsumerRecord<T, T>> iterator = records.iterator();
+                         messages.size() != expectedMessages && iterator.hasNext(); ) {
+
+                        ConsumerRecord<T, T> rec = iterator.next();
                         LOGGER.debug("Received message: {} -> {}, offset {}", rec.key(), rec.value(), rec.offset());
                         messages.add(rec.value());
                         consumer.commitSync(singletonMap(new TopicPartition(rec.topic(), rec.partition()),

--- a/src/main/java/com/github/charithe/kafka/KafkaJunitRule.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitRule.java
@@ -24,7 +24,9 @@ import org.apache.curator.test.TestingServer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -44,6 +46,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.*;
 
+import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class KafkaJunitRule extends ExternalResource {
@@ -192,7 +195,7 @@ public class KafkaJunitRule extends ExternalResource {
         Properties props = new Properties();
         props.put("bootstrap.servers", LOCALHOST + ":" + kafkaPort);
         props.put("group.id", "kafka-junit-consumer");
-        props.put("enable.auto.commit", "true");
+        props.put("enable.auto.commit", "false");
         props.put("auto.commit.interval.ms", "200");
         props.put("auto.offset.reset", "earliest");
         props.put("heartbeat.interval.ms", "100");
@@ -266,30 +269,40 @@ public class KafkaJunitRule extends ExternalResource {
     public <T> List<T> readMessages(final KafkaConsumer<T, T> consumer, final String topic, final int expectedMessages,
                                     final int timeoutSeconds) throws TimeoutException {
         ExecutorService singleThread = Executors.newSingleThreadExecutor();
-        try {
-            consumer.subscribe(Lists.newArrayList(topic));
-            Future<List<T>> future = singleThread.submit(new Callable<List<T>>() {
-                @Override
-                public List<T> call() throws Exception {
-                    List<T> messages = new ArrayList<>(expectedMessages);
-                    while (messages.size() < expectedMessages) {
-                        ConsumerRecords<T, T> records = consumer.poll(POLL_TIMEOUT_MS);
-                        for (ConsumerRecord<T, T> rec : records) {
-                            LOGGER.debug("Received message: {} -> {}", rec.key(), rec.value());
-                            messages.add(rec.value());
-                        }
+        consumer.subscribe(Lists.newArrayList(topic));
+        Future<List<T>> future = singleThread.submit(new Callable<List<T>>() {
+            @Override
+            public List<T> call() throws Exception {
+                List<T> messages = new ArrayList<>(expectedMessages);
+                while (messages.size() < expectedMessages && !Thread.currentThread().isInterrupted()) {
+                    ConsumerRecords<T, T> records = consumer.poll(POLL_TIMEOUT_MS);
+                    for (ConsumerRecord<T, T> rec : records) {
+                        LOGGER.debug("Received message: {} -> {}, offset {}", rec.key(), rec.value(), rec.offset());
+                        messages.add(rec.value());
+                        consumer.commitSync(singletonMap(new TopicPartition(rec.topic(), rec.partition()),
+                                                         new OffsetAndMetadata(rec.offset() + 1)));
                     }
-                    return messages;
                 }
-            });
+                return messages;
+            }
+        });
 
+        try {
             return future.get(timeoutSeconds, SECONDS);
-        } catch (TimeoutException | InterruptedException | ExecutionException e) {
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw new TimeoutException("Timed out waiting for messages");
+        } catch (InterruptedException | ExecutionException e) {
             throw new TimeoutException("Timed out waiting for messages");
         } catch (Exception e) {
             throw new RuntimeException("Unexpected exception while reading messages", e);
         } finally {
             singleThread.shutdown();
+            try {
+                singleThread.awaitTermination(5, SECONDS);
+            } catch (InterruptedException e) {
+                singleThread.shutdownNow();
+            }
         }
     }
 

--- a/src/test/java/com/github/charithe/kafka/KafkaJunitClassRuleTest.java
+++ b/src/test/java/com/github/charithe/kafka/KafkaJunitClassRuleTest.java
@@ -39,6 +39,8 @@ public class KafkaJunitClassRuleTest {
     private static final String VALUE_1 = "valueY1";
     private static final String KEY_2 = "keyY2";
     private static final String VALUE_2 = "valueY2";
+    private static final String KEY_3 = "keyY3";
+    private static final String VALUE_3 = "valueY3";
 
     @ClassRule
     public static KafkaJunitRule kafkaRule = new KafkaJunitRule();
@@ -89,7 +91,7 @@ public class KafkaJunitClassRuleTest {
     @Test
     public void testNoDuplicateMessagesAreRead() throws TimeoutException {
         try (KafkaProducer<String, String> producer = kafkaRule.createStringProducer()) {
-            producer.send(new ProducerRecord<>(TOPIC, KEY_1, VALUE_2));
+            producer.send(new ProducerRecord<>(TOPIC, KEY_3, VALUE_3));
         }
 
         kafkaRule.readStringMessages(TOPIC, 1, 1);
@@ -99,5 +101,17 @@ public class KafkaJunitClassRuleTest {
         } catch (TimeoutException e) {
             // expected
         }
+    }
+
+    @Test
+    public void testExactNumberOfMessagesAreRead() throws TimeoutException {
+        try (KafkaProducer<String, String> producer = kafkaRule.createStringProducer()) {
+            producer.send(new ProducerRecord<>(TOPIC, KEY_1, VALUE_2));
+            producer.send(new ProducerRecord<>(TOPIC, KEY_1, VALUE_3));
+            producer.send(new ProducerRecord<>(TOPIC, KEY_2, VALUE_3));
+        }
+
+        assertThat(kafkaRule.readStringMessages(TOPIC, 1, 1).size(), is(1));
+        assertThat(kafkaRule.readStringMessages(TOPIC, 2, 1).size(), is(2));
     }
 }

--- a/src/test/java/com/github/charithe/kafka/KafkaJunitRuleTest.java
+++ b/src/test/java/com/github/charithe/kafka/KafkaJunitRuleTest.java
@@ -99,4 +99,16 @@ public class KafkaJunitRuleTest {
             // expected
         }
     }
+
+    @Test
+    public void testExactNumberOfMessagesAreRead() throws TimeoutException {
+        try (KafkaProducer<String, String> producer = kafkaRule.createStringProducer()) {
+            producer.send(new ProducerRecord<>(TOPIC, KEY, VALUE));
+            producer.send(new ProducerRecord<>(TOPIC, KEY, VALUE));
+            producer.send(new ProducerRecord<>(TOPIC, KEY, VALUE));
+        }
+
+        assertThat(kafkaRule.readStringMessages(TOPIC, 1, 1).size(), is(1));
+        assertThat(kafkaRule.readStringMessages(TOPIC, 2, 1).size(), is(2));
+    }
 }


### PR DESCRIPTION
Hi Charith, I hope you well.
We have been using your library in our tests, but we ran into some issues:
1 - It is possible to read the same message multiple times, even though the consumer configuration has auto commit enabled.
2 - The number of messages read is actually dependent on the poll configuration instead of the specified expected number of messages.

I created a test for each of these scenarios together with a proposed solution.
Cheers