### PR TITLE
Update to kafka 0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <java.version>1.7</java.version>
-        <kafka.version>0.9.0.1</kafka.version>
+        <kafka.version>0.10.0.0</kafka.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Only requires a version bump, no critical API changes.