### PR TITLE
Add Junit 5 support. Create KafkaJunitExtension to replace KafkaJunitRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-Kafka JUnit Rule [![Build Status](https://travis-ci.org/charithe/kafka-junit.svg?branch=master)](https://travis-ci.org/charithe/kafka-junit) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.charithe/kafka-junit/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.charithe/kafka-junit)
-=================
+Kafka JUnit [![Build Status](https://travis-ci.org/charithe/kafka-junit.svg?branch=master)](https://travis-ci.org/charithe/kafka-junit) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.charithe/kafka-junit/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.charithe/kafka-junit)
+===========
 
-JUnit rule for starting and tearing down a Kafka broker during tests.
+Kafka Junit provides a JUnit rule for starting and tearing down a Kafka broker during tests.
+
+It also provides a JUnit 5 Extension to do this, as rules are no longer natively supported in JUnit 5.
+
 
 **Please note that version 3.x.x drops Java 7 support and contains breaking API changes.** 
 
@@ -82,5 +85,37 @@ public void testSomething(){
 `EphemeralKafkaBroker` contains the core logic used by the JUnit rule and can be used independently. 
 
 `KafkaHelper` contains a bunch of convenience methods to work with the `EphemeralKafkaBroker` 
+
+#### JUnit 5 Usage
+
+JUnit 5 does not have support for Rules, but instead uses the new [JUnit 5 Extension Model](http://junit.org/junit5/docs/current/user-guide/#extensions).
+
+So if you are using JUnit 5 you can use `KafkaJunitExtension` which provides a kafka broker that is started and stopped for each test.
+
+The extension is configured using the optional class annotation `@KafkaJunitExtensionConfig` and provides
+dependency injection for constructors and methods for the classes `KafkaHelper` and `EphemeralKafkaBroker`
+
+```java
+@ExtendWith(KafkaJunitExtension.class)
+@KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP)
+class MyTestClass {
+    
+    @Test
+    void testSomething(KafkaHelper kafkaHelper){
+        // Convenience methods to produce and consume messages
+        kafkaHelper.produceStrings("my-test-topic", "a", "b", "c", "d", "e");
+        List<String> result = kafkaHelper.consumeStrings("my-test-topic", 5).get();
+    
+        // or use the built-in producers and consumers
+        KafkaProducer<String, String> producer = kafkaHelper.createStringProducer();
+    
+        KafkaConsumer<String, String> consumer = kafkaHelper.createStringConsumer();
+    
+        // Alternatively, the Zookeeper connection String and the broker port can be retrieved to generate your own config
+        String zkConnStr = kafkaHelper.zookeeperConnectionString();
+        int brokerPort = kafkaHelper.kafkaPort();
+    }
+}
+```
 
 Refer to [Javadocs](http://charithe.github.io/kafka-junit/) and unit tests for more usage examples.

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,13 @@
     </prerequisites>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <kafka.version>1.0.0</kafka.version>
+        <junit.version>4.12</junit.version>
+        <junit.jupiter.version>5.1.0-M1</junit.jupiter.version>
+        <junit.vintage.version>5.1.0-M1</junit.vintage.version>
+        <junit.platform.version>1.1.0-M1</junit.platform.version>
     </properties>
 
     <scm>
@@ -106,10 +111,15 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
         </dependency>
 
-        <!-- Test dependencies -->
+        <!-- TEST DEPENDENCIES -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -121,6 +131,33 @@
             <artifactId>assertj-core</artifactId>
             <version>3.8.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- Only required to run tests in an IDE that bundles an older version -->
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit.platform.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- Only required to run tests in an IDE that bundles an older version -->
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.vintage.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- To avoid compiler warnings about @API annotations in JUnit code -->
+            <groupId>org.apiguardian</groupId>
+            <artifactId>apiguardian-api</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>
@@ -226,6 +263,17 @@
                     <pubScmUrl>scm:git:ssh://git@github.com/charithe/kafka-junit.git</pubScmUrl>
                     <scmBranch>gh-pages</scmBranch>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit.platform.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/github/charithe/kafka/KafkaJunitExtension.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitExtension.java
@@ -1,0 +1,96 @@
+package com.github.charithe.kafka;
+
+import com.google.common.util.concurrent.Futures;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * <p>{@code KafkaJunitExtension} provides a kafka broker that is started and stopped for each test</p>
+ * <p>
+ * It is configured by the optional annotation @{@link KafkaJunitExtensionConfig} and provides
+ * dependency injection for constructors and methods for the classes {@link KafkaHelper} and {@link EphemeralKafkaBroker}
+ * </p>
+ * <br>
+ * <b>Usage:</b>
+ * <pre>
+ * {@code @ExtendWith(KafkaJunitExtension.class)
+ *  @literal @KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP)
+ *   class MyTestClass {
+ *
+ *      @literal @BeforeEach
+ *       void setUp(KafkaHelper kafkaHelper, EphemeralKafkaBroker broker) {
+ *
+ *       }
+ *  }
+ * }
+ * </pre>
+ */
+@KafkaJunitExtensionConfig
+public class KafkaJunitExtension implements BeforeAllCallback, AfterEachCallback, BeforeEachCallback, ParameterResolver {
+
+    private static final ExtensionContext.Namespace KAFKA_JUNIT = ExtensionContext.Namespace.create("kafka-junit");
+    private static final KafkaJunitExtensionConfig DEFAULT_CONFIG = KafkaJunitExtension.class.getAnnotation(KafkaJunitExtensionConfig.class);
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        KafkaJunitExtensionConfig kafkaConfig = getKafkaConfig(extensionContext);
+        EphemeralKafkaBroker broker = EphemeralKafkaBroker.create(kafkaConfig.kafkaPort(), kafkaConfig.zooKeeperPort());
+        extensionContext.getStore(KAFKA_JUNIT).put(EphemeralKafkaBroker.class, broker);
+        extensionContext.getStore(KAFKA_JUNIT).put(StartupMode.class, kafkaConfig.startupMode());
+        extensionContext.getStore(KAFKA_JUNIT).put(KafkaHelper.class, KafkaHelper.createFor(broker));
+    }
+
+    private static KafkaJunitExtensionConfig getKafkaConfig(ExtensionContext extensionContext) {
+        return extensionContext.getElement().map(annotatedElement -> {
+            if (annotatedElement.isAnnotationPresent(KafkaJunitExtensionConfig.class)) {
+                return annotatedElement.getAnnotation(KafkaJunitExtensionConfig.class);
+            } else {
+                return DEFAULT_CONFIG;
+            }
+        }).orElse(DEFAULT_CONFIG);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        CompletableFuture<Void> startFuture = getBroker(extensionContext).start();
+        if (getStartupMode(extensionContext) == StartupMode.WAIT_FOR_STARTUP) {
+            Futures.getUnchecked(startFuture);
+        }
+    }
+
+    private static EphemeralKafkaBroker getBroker(ExtensionContext extensionContext) {
+        return extensionContext.getStore(KAFKA_JUNIT).get(EphemeralKafkaBroker.class, EphemeralKafkaBroker.class);
+    }
+
+    private static StartupMode getStartupMode(ExtensionContext extensionContext) {
+        return extensionContext.getStore(KAFKA_JUNIT).get(StartupMode.class, StartupMode.class);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) {
+        try {
+            getBroker(extensionContext).stop();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.getParameter().getType().equals(KafkaHelper.class) || parameterContext.getParameter().getType().equals(EphemeralKafkaBroker.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        Class<?> parameterType = parameterContext.getParameter().getType();
+        return extensionContext.getStore(KAFKA_JUNIT).get(parameterType, parameterType);
+    }
+
+}

--- a/src/main/java/com/github/charithe/kafka/KafkaJunitExtensionConfig.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitExtensionConfig.java
@@ -1,0 +1,20 @@
+package com.github.charithe.kafka;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface KafkaJunitExtensionConfig {
+
+    int ALLOCATE_RANDOM_PORT = -1;
+
+    int kafkaPort() default ALLOCATE_RANDOM_PORT;
+
+    int zooKeeperPort() default ALLOCATE_RANDOM_PORT;
+
+    StartupMode startupMode() default StartupMode.DEFAULT;
+
+}

--- a/src/main/java/com/github/charithe/kafka/KafkaJunitRule.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitRule.java
@@ -83,7 +83,4 @@ public class KafkaJunitRule extends ExternalResource {
         return new KafkaJunitRule(EphemeralKafkaBroker.create());
     }
 
-    private enum StartupMode {
-        WAIT_FOR_STARTUP, DEFAULT
-    }
 }

--- a/src/main/java/com/github/charithe/kafka/StartupMode.java
+++ b/src/main/java/com/github/charithe/kafka/StartupMode.java
@@ -1,0 +1,6 @@
+package com.github.charithe.kafka;
+
+public enum StartupMode {
+    WAIT_FOR_STARTUP,
+    DEFAULT
+}

--- a/src/test/java/com/github/charithe/kafka/KafkaJunitExtensionConfigTest.java
+++ b/src/test/java/com/github/charithe/kafka/KafkaJunitExtensionConfigTest.java
@@ -1,0 +1,49 @@
+package com.github.charithe.kafka;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class KafkaJunitExtensionConfigTest {
+
+    @Nested
+    @KafkaJunitExtensionConfig
+    static class DefaultConfigTest {
+
+        @Test
+        void default_values_are_set() {
+            KafkaJunitExtensionConfig defaultConfig = DefaultConfigTest.class.getAnnotation(KafkaJunitExtensionConfig.class);
+            Assertions.assertAll(() -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.kafkaPort()),
+                                 () -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.zooKeeperPort()),
+                                 () -> Assertions.assertEquals(StartupMode.DEFAULT, defaultConfig.startupMode()));
+        }
+    }
+
+    @Nested
+    @KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP)
+    static class PartialConfigTest {
+
+        @Test
+        void unset_values_are_set_to_default() {
+            KafkaJunitExtensionConfig defaultConfig = PartialConfigTest.class.getAnnotation(KafkaJunitExtensionConfig.class);
+            Assertions.assertAll(() -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.kafkaPort()),
+                                 () -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.zooKeeperPort()),
+                                 () -> Assertions.assertEquals(StartupMode.WAIT_FOR_STARTUP, defaultConfig.startupMode()));
+        }
+    }
+
+    @Nested
+    @KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP, kafkaPort = 1234, zooKeeperPort = 5678)
+    static class FullConfigTest {
+
+        @Test
+        void unset_values_are_set_to_default() {
+            KafkaJunitExtensionConfig defaultConfig = FullConfigTest.class.getAnnotation(KafkaJunitExtensionConfig.class);
+            Assertions.assertAll(() -> Assertions.assertEquals(1234, defaultConfig.kafkaPort()),
+                                 () -> Assertions.assertEquals(5678, defaultConfig.zooKeeperPort()),
+                                 () -> Assertions.assertEquals(StartupMode.WAIT_FOR_STARTUP, defaultConfig.startupMode()));
+        }
+    }
+
+
+}

--- a/src/test/java/com/github/charithe/kafka/KafkaJunitExtensionTest.java
+++ b/src/test/java/com/github/charithe/kafka/KafkaJunitExtensionTest.java
@@ -1,0 +1,95 @@
+package com.github.charithe.kafka;
+
+import com.google.common.collect.Lists;
+import kafka.admin.AdminUtils;
+import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.ZkConnection;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaJunitExtensionTest {
+
+    private static final String TOPIC = "topicX";
+
+    @Nested
+    @ExtendWith(KafkaJunitExtension.class)
+    class BaseTest {
+
+        @Test
+        void testKafkaServerIsUp(KafkaHelper kafkaHelper) {
+            try (KafkaProducer<String, String> producer = kafkaHelper.createStringProducer()) {
+                producer.send(new ProducerRecord<>(TOPIC, "keyA", "valueA"));
+            }
+
+            try (KafkaConsumer<String, String> consumer = kafkaHelper.createStringConsumer()) {
+                consumer.subscribe(Lists.newArrayList(TOPIC));
+                ConsumerRecords<String, String> records = consumer.poll(10000);
+                Assertions.assertAll(() -> assertThat(records).isNotNull(),
+                                     () -> assertThat(records.isEmpty()).isFalse());
+
+                ConsumerRecord<String, String> msg = records.iterator().next();
+                Assertions.assertAll(() -> assertThat(msg).isNotNull(),
+                                     () -> assertThat(msg.key()).isEqualTo("keyA"),
+                                     () -> assertThat(msg.value()).isEqualTo("valueA"));
+            }
+        }
+
+    }
+
+    @Nested
+    @ExtendWith(KafkaJunitExtension.class)
+    @KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP)
+    class WaitForStartup {
+
+        @Test
+        void testKafkaServerIsUp(KafkaHelper kafkaHelper) {
+            // Setup Zookeeper client
+            final String zkConnectionString = kafkaHelper.zookeeperConnectionString();
+            final ZkClient zkClient = new ZkClient(
+                                                      zkConnectionString, 1000, 8000, ZKStringSerializer$.MODULE$
+            );
+            final ZkConnection zkConnection = new ZkConnection(zkConnectionString);
+            final ZkUtils zkUtils = new ZkUtils(zkClient, zkConnection, false);
+
+            // Create topic
+            AdminUtils.createTopic(zkUtils, TOPIC, 1, 1, new Properties(), null);
+
+            // Produce/consume test
+            try (KafkaProducer<String, String> producer = kafkaHelper.createStringProducer()) {
+                producer.send(new ProducerRecord<>(TOPIC, "keyA", "valueA"));
+            }
+
+            try (KafkaConsumer<String, String> consumer = kafkaHelper.createStringConsumer()) {
+                consumer.subscribe(Lists.newArrayList(TOPIC));
+                ConsumerRecords<String, String> records = consumer.poll(10000);
+                Assertions.assertAll(() -> assertThat(records).isNotNull(),
+                                     () -> assertThat(records.isEmpty()).isFalse());
+
+                ConsumerRecord<String, String> msg = records.iterator().next();
+                Assertions.assertAll(() -> assertThat(msg).isNotNull(),
+                                     () -> assertThat(msg.key()).isEqualTo("keyA"),
+                                     () -> assertThat(msg.value()).isEqualTo("valueA"));
+            }
+        }
+
+        @Test
+        void brokerIsStarted(EphemeralKafkaBroker broker) {
+            assertThat(broker.isRunning()).isTrue();
+        }
+
+    }
+}

--- a/src/test/java/com/github/charithe/kafka/KafkaJunitRuleTest.java
+++ b/src/test/java/com/github/charithe/kafka/KafkaJunitRuleTest.java
@@ -19,7 +19,6 @@ package com.github.charithe.kafka;
 import com.google.common.collect.Lists;
 import java.util.Properties;
 import kafka.admin.AdminUtils;
-import kafka.admin.RackAwareMode;
 import kafka.utils.ZKStringSerializer$;
 import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;


### PR DESCRIPTION
Hey Charith,
I'd like to add junit 5 support, which means using an Extension instead of a Rule to spin up the broker. See http://junit.org/junit5/docs/current/user-guide/#extensions

Let me know what you think.

Thanks!
Tomás