### PR TITLE
Upgraded kafka to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <kafka.version>1.0.0</kafka.version>
+        <kafka.version>1.1.0</kafka.version>
         <junit.version>4.12</junit.version>
         <junit.jupiter.version>5.1.0-M1</junit.jupiter.version>
         <junit.vintage.version>5.1.0-M1</junit.vintage.version>

--- a/src/main/java/com/github/charithe/kafka/EphemeralKafkaBroker.java
+++ b/src/main/java/com/github/charithe/kafka/EphemeralKafkaBroker.java
@@ -144,7 +144,7 @@ public class EphemeralKafkaBroker {
         LOGGER.info("Starting Kafka server with config: {}", kafkaConfig.props());
         kafkaServer = new KafkaServerStartable(kafkaConfig);
         brokerStarted = true;
-        final Integer brokerId = kafkaServer.serverConfig().getInt(KafkaConfig.BrokerIdProp());
+        final Integer brokerId = kafkaServer.staticServerConfig().getInt(KafkaConfig.BrokerIdProp());
         if(brokerId != null) {
             /* Avoid warning for missing meta.properties */
             Files.write(kafkaLogDir.resolve("meta.properties"), ("version=0\nbroker.id=" + brokerId).getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Tests were green locally and only a slight rename was a breaking change, at least as far I can tell.