### PR TITLE
Upgrade Guava dependency to current version 27.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.3-jre</version>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/github/charithe/kafka/KafkaHelper.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaHelper.java
@@ -274,7 +274,7 @@ public class KafkaHelper {
     public ListenableFuture<List<String>> consumeStrings(String topic, int numMessagesToConsume) {
         KafkaConsumer<String, String> consumer = createStringConsumer();
         ListenableFuture<List<ConsumerRecord<String, String>>> records = consume(topic, consumer, numMessagesToConsume);
-        return Futures.transform(records, this::extractValues);
+        return Futures.transform(records, this::extractValues, MoreExecutors.directExecutor());
     }
 
     private List<String> extractValues(List<ConsumerRecord<String, String>> records) {


### PR DESCRIPTION
`Futures.transform(ListenableFuture, Function)` has been deprecated for some time, and has been removed with [Guava 26.0](https://github.com/google/guava/releases/tag/v26.0).

In order to work with newer versions of Guava, use the variant of `transform` with an explicit `directExecutor`. This does not change the semantics, the variant without the `Executor` parameter did in fact use `directExecutor`.

This change is backwards compatible, meaning that this should work with all versions of Guava that did work before: Both variants of `transform()` were added in Guava 9.0, and the deprecated one was removed in 26.0, so this particular line is compatible with 9.0 through 26.0 at least.