### PR TITLE
Enabled properties override on annotation

### DIFF
--- a/src/main/java/com/github/charithe/kafka/KafkaJunitExtension.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitExtension.java
@@ -1,6 +1,12 @@
 package com.github.charithe.kafka;
 
-import com.google.common.util.concurrent.Futures;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -8,15 +14,17 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import com.google.common.util.concurrent.Futures;
 
 /**
- * {@code KafkaJunitExtension} provides a kafka broker that is started and stopped for each test. It is configured by
- * the optional annotation @{@link KafkaJunitExtensionConfig} and provides dependency injection for constructors and
- * methods for the classes {@link KafkaHelper} and {@link EphemeralKafkaBroker}
+ * {@code KafkaJunitExtension} provides a kafka broker that is started and
+ * stopped for each test. It is configured by the optional
+ * annotation @{@link KafkaJunitExtensionConfig} and provides dependency
+ * injection for constructors and methods for the classes {@link KafkaHelper}
+ * and {@link EphemeralKafkaBroker}
  *
  * Usage:
+ * 
  * <pre>
  *     <code>
  * {@literal @}ExtendWith(KafkaJunitExtension.class)
@@ -32,66 +40,79 @@ import java.util.concurrent.ExecutionException;
  */
 @KafkaJunitExtensionConfig
 public class KafkaJunitExtension
-    implements BeforeAllCallback, AfterEachCallback, BeforeEachCallback, ParameterResolver {
+		implements BeforeAllCallback, AfterEachCallback, BeforeEachCallback, ParameterResolver {
 
-    private static final ExtensionContext.Namespace KAFKA_JUNIT = ExtensionContext.Namespace.create("kafka-junit");
-    private static final KafkaJunitExtensionConfig DEFAULT_CONFIG =
-        KafkaJunitExtension.class.getAnnotation(KafkaJunitExtensionConfig.class);
+	private static final ExtensionContext.Namespace KAFKA_JUNIT = ExtensionContext.Namespace.create("kafka-junit");
+	private static final KafkaJunitExtensionConfig DEFAULT_CONFIG = KafkaJunitExtension.class
+			.getAnnotation(KafkaJunitExtensionConfig.class);
 
-    @Override
-    public void beforeAll(ExtensionContext extensionContext) {
-        KafkaJunitExtensionConfig kafkaConfig = getKafkaConfig(extensionContext);
-        EphemeralKafkaBroker broker = EphemeralKafkaBroker.create(kafkaConfig.kafkaPort(), kafkaConfig.zooKeeperPort());
-        extensionContext.getStore(KAFKA_JUNIT).put(EphemeralKafkaBroker.class, broker);
-        extensionContext.getStore(KAFKA_JUNIT).put(StartupMode.class, kafkaConfig.startupMode());
-        extensionContext.getStore(KAFKA_JUNIT).put(KafkaHelper.class, KafkaHelper.createFor(broker));
-    }
+	@Override
+	public void beforeAll(ExtensionContext extensionContext) {
+		KafkaJunitExtensionConfig kafkaConfig = getKafkaConfig(extensionContext);
+		EphemeralKafkaBroker broker = EphemeralKafkaBroker.create(kafkaConfig.kafkaPort(), kafkaConfig.zooKeeperPort(),
+				loadPropsFromFile(kafkaConfig.propsPath()));
+		extensionContext.getStore(KAFKA_JUNIT).put(EphemeralKafkaBroker.class, broker);
+		extensionContext.getStore(KAFKA_JUNIT).put(StartupMode.class, kafkaConfig.startupMode());
+		extensionContext.getStore(KAFKA_JUNIT).put(KafkaHelper.class, KafkaHelper.createFor(broker));
+	}
 
-    private static KafkaJunitExtensionConfig getKafkaConfig(ExtensionContext extensionContext) {
-        return extensionContext.getElement().map(annotatedElement -> {
-            if (annotatedElement.isAnnotationPresent(KafkaJunitExtensionConfig.class)) {
-                return annotatedElement.getAnnotation(KafkaJunitExtensionConfig.class);
-            } else {
-                return DEFAULT_CONFIG;
-            }
-        }).orElse(DEFAULT_CONFIG);
-    }
+	private static KafkaJunitExtensionConfig getKafkaConfig(ExtensionContext extensionContext) {
+		return extensionContext.getElement().map(annotatedElement -> {
+			if (annotatedElement.isAnnotationPresent(KafkaJunitExtensionConfig.class)) {
+				return annotatedElement.getAnnotation(KafkaJunitExtensionConfig.class);
+			} else {
+				return DEFAULT_CONFIG;
+			}
+		}).orElse(DEFAULT_CONFIG);
+	}
 
-    @Override
-    public void beforeEach(ExtensionContext extensionContext) throws Exception {
-        CompletableFuture<Void> startFuture = getBroker(extensionContext).start();
-        if (getStartupMode(extensionContext) == StartupMode.WAIT_FOR_STARTUP) {
-            Futures.getUnchecked(startFuture);
-        }
-    }
+	@Override
+	public void beforeEach(ExtensionContext extensionContext) throws Exception {
+		CompletableFuture<Void> startFuture = getBroker(extensionContext).start();
+		if (getStartupMode(extensionContext) == StartupMode.WAIT_FOR_STARTUP) {
+			Futures.getUnchecked(startFuture);
+		}
+	}
 
-    private static EphemeralKafkaBroker getBroker(ExtensionContext extensionContext) {
-        return extensionContext.getStore(KAFKA_JUNIT).get(EphemeralKafkaBroker.class, EphemeralKafkaBroker.class);
-    }
+	private static EphemeralKafkaBroker getBroker(ExtensionContext extensionContext) {
+		return extensionContext.getStore(KAFKA_JUNIT).get(EphemeralKafkaBroker.class, EphemeralKafkaBroker.class);
+	}
 
-    private static StartupMode getStartupMode(ExtensionContext extensionContext) {
-        return extensionContext.getStore(KAFKA_JUNIT).get(StartupMode.class, StartupMode.class);
-    }
+	private static StartupMode getStartupMode(ExtensionContext extensionContext) {
+		return extensionContext.getStore(KAFKA_JUNIT).get(StartupMode.class, StartupMode.class);
+	}
 
-    @Override
-    public void afterEach(ExtensionContext extensionContext) {
-        try {
-            getBroker(extensionContext).stop();
-        } catch (ExecutionException | InterruptedException e) {
-            throw new AssertionError(e);
-        }
-    }
+	@Override
+	public void afterEach(ExtensionContext extensionContext) {
+		try {
+			getBroker(extensionContext).stop();
+		} catch (ExecutionException | InterruptedException e) {
+			throw new AssertionError(e);
+		}
+	}
 
-    @Override
-    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-        return parameterContext.getParameter().getType().equals(KafkaHelper.class) || parameterContext.getParameter()
-            .getType()
-            .equals(EphemeralKafkaBroker.class);
-    }
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+		return parameterContext.getParameter().getType().equals(KafkaHelper.class)
+				|| parameterContext.getParameter().getType().equals(EphemeralKafkaBroker.class);
+	}
 
-    @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-        Class<?> parameterType = parameterContext.getParameter().getType();
-        return extensionContext.getStore(KAFKA_JUNIT).get(parameterType, parameterType);
-    }
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+		Class<?> parameterType = parameterContext.getParameter().getType();
+		return extensionContext.getStore(KAFKA_JUNIT).get(parameterType, parameterType);
+	}
+
+	private Properties loadPropsFromFile(String path) {
+		Properties prop = new Properties();
+		if (!path.isBlank()) {
+			try (InputStream input = new FileInputStream(path)) {
+				prop.load(input);
+			} catch (IOException ex) {
+				throw new RuntimeException(ex);
+			}
+		}
+		return prop;
+	}
+
 }

--- a/src/main/java/com/github/charithe/kafka/KafkaJunitExtensionConfig.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitExtensionConfig.java
@@ -17,6 +17,6 @@ public @interface KafkaJunitExtensionConfig {
 
     StartupMode startupMode() default StartupMode.DEFAULT;
     
-    String propsPath() default "";
+    String propsFileName() default "";
     
 }

--- a/src/main/java/com/github/charithe/kafka/KafkaJunitExtensionConfig.java
+++ b/src/main/java/com/github/charithe/kafka/KafkaJunitExtensionConfig.java
@@ -16,4 +16,7 @@ public @interface KafkaJunitExtensionConfig {
     int zooKeeperPort() default ALLOCATE_RANDOM_PORT;
 
     StartupMode startupMode() default StartupMode.DEFAULT;
+    
+    String propsPath() default "";
+    
 }

--- a/src/test/java/com/github/charithe/kafka/KafkaJunitExtensionConfigTest.java
+++ b/src/test/java/com/github/charithe/kafka/KafkaJunitExtensionConfigTest.java
@@ -16,7 +16,7 @@ class KafkaJunitExtensionConfigTest {
             Assertions.assertAll(() -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.kafkaPort()),
                                  () -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.zooKeeperPort()),
                                  () -> Assertions.assertEquals(StartupMode.DEFAULT, defaultConfig.startupMode()),
-                                 () -> Assertions.assertEquals("", defaultConfig.propsPath()));
+                                 () -> Assertions.assertEquals("", defaultConfig.propsFileName()));
         }
     }
 
@@ -30,12 +30,12 @@ class KafkaJunitExtensionConfigTest {
             Assertions.assertAll(() -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.kafkaPort()),
                                  () -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.zooKeeperPort()),
                                  () -> Assertions.assertEquals(StartupMode.WAIT_FOR_STARTUP, defaultConfig.startupMode()),
-                                 () -> Assertions.assertEquals("", defaultConfig.propsPath()));
+                                 () -> Assertions.assertEquals("", defaultConfig.propsFileName()));
         }
     }
 
     @Nested
-    @KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP, kafkaPort = 1234, zooKeeperPort = 5678, propsPath = "src/main/resources/config.properties")
+    @KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP, kafkaPort = 1234, zooKeeperPort = 5678, propsFileName = "src/main/resources/config.properties")
     static class FullConfigTest {
 
         @Test
@@ -44,7 +44,7 @@ class KafkaJunitExtensionConfigTest {
             Assertions.assertAll(() -> Assertions.assertEquals(1234, defaultConfig.kafkaPort()),
                                  () -> Assertions.assertEquals(5678, defaultConfig.zooKeeperPort()),
                                  () -> Assertions.assertEquals(StartupMode.WAIT_FOR_STARTUP, defaultConfig.startupMode()),
-                                 () -> Assertions.assertEquals("src/main/resources/config.properties", defaultConfig.propsPath()));
+                                 () -> Assertions.assertEquals("src/main/resources/config.properties", defaultConfig.propsFileName()));
         }
     }
 

--- a/src/test/java/com/github/charithe/kafka/KafkaJunitExtensionConfigTest.java
+++ b/src/test/java/com/github/charithe/kafka/KafkaJunitExtensionConfigTest.java
@@ -15,7 +15,8 @@ class KafkaJunitExtensionConfigTest {
             KafkaJunitExtensionConfig defaultConfig = DefaultConfigTest.class.getAnnotation(KafkaJunitExtensionConfig.class);
             Assertions.assertAll(() -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.kafkaPort()),
                                  () -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.zooKeeperPort()),
-                                 () -> Assertions.assertEquals(StartupMode.DEFAULT, defaultConfig.startupMode()));
+                                 () -> Assertions.assertEquals(StartupMode.DEFAULT, defaultConfig.startupMode()),
+                                 () -> Assertions.assertEquals("", defaultConfig.propsPath()));
         }
     }
 
@@ -28,12 +29,13 @@ class KafkaJunitExtensionConfigTest {
             KafkaJunitExtensionConfig defaultConfig = PartialConfigTest.class.getAnnotation(KafkaJunitExtensionConfig.class);
             Assertions.assertAll(() -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.kafkaPort()),
                                  () -> Assertions.assertEquals(KafkaJunitExtensionConfig.ALLOCATE_RANDOM_PORT, defaultConfig.zooKeeperPort()),
-                                 () -> Assertions.assertEquals(StartupMode.WAIT_FOR_STARTUP, defaultConfig.startupMode()));
+                                 () -> Assertions.assertEquals(StartupMode.WAIT_FOR_STARTUP, defaultConfig.startupMode()),
+                                 () -> Assertions.assertEquals("", defaultConfig.propsPath()));
         }
     }
 
     @Nested
-    @KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP, kafkaPort = 1234, zooKeeperPort = 5678)
+    @KafkaJunitExtensionConfig(startupMode = StartupMode.WAIT_FOR_STARTUP, kafkaPort = 1234, zooKeeperPort = 5678, propsPath = "src/main/resources/config.properties")
     static class FullConfigTest {
 
         @Test
@@ -41,7 +43,8 @@ class KafkaJunitExtensionConfigTest {
             KafkaJunitExtensionConfig defaultConfig = FullConfigTest.class.getAnnotation(KafkaJunitExtensionConfig.class);
             Assertions.assertAll(() -> Assertions.assertEquals(1234, defaultConfig.kafkaPort()),
                                  () -> Assertions.assertEquals(5678, defaultConfig.zooKeeperPort()),
-                                 () -> Assertions.assertEquals(StartupMode.WAIT_FOR_STARTUP, defaultConfig.startupMode()));
+                                 () -> Assertions.assertEquals(StartupMode.WAIT_FOR_STARTUP, defaultConfig.startupMode()),
+                                 () -> Assertions.assertEquals("src/main/resources/config.properties", defaultConfig.propsPath()));
         }
     }
 


### PR DESCRIPTION
Added properties file path as a new KafkaJunitExtensionConfig parameter in order to override KafkaConfig properties. 

Useful feature for overriding default kafka configs and keep using @KafkaJunitExtensionConfig instead of having to create an own EphemeralKafkaBroker each time.

loadPropsFromFile method could be better on EphemeralKafkaBroker.create in order to handle exceptions properly (didn't want to change so much of your code)